### PR TITLE
SEEDSVT-318 SSRF_ON flag to turn off SSRF validation e.g. for local REST Service instance

### DIFF
--- a/docker-compose.frontend.yml
+++ b/docker-compose.frontend.yml
@@ -64,6 +64,7 @@ services:
       - KPI_UWSGI_CHEAPER_WORKERS_COUNT=1
       - KPI_UWSGI_HARAKIRI=120
       - KPI_UWSGI_WORKER_RELOAD_MERCY=120
+      - SSRF_ON=True # Set to False to allow using private IPs/bypass SSRF validation for local REST Service instance
     volumes:
       - ./.vols/static/kpi:/srv/static
       - ./log/kpi:/srv/logs


### PR DESCRIPTION
We'll merge or close this change based on https://github.com/devgateway/kobotoolbox-kpi/pull/1 outcome.